### PR TITLE
Fix: Passed parameters do not have any effect on build.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,25 +3,25 @@
 
 TASMOTA_VOLUME='/tasmota'
 USER_CONFIG_OVERRIDE="${TASMOTA_VOLUME}/tasmota/user_config_override.h"
+export PLATFORMIO_BUILD_FLAGS='-DUSE_CONFIG_OVERRIDE'
 
 
 if [ -d $TASMOTA_VOLUME ]; then
 	cd $TASMOTA_VOLUME
 	if [ -n "$(env | grep ^TASMOTA_)" ]; then
 		echo "Deleting original $USER_CONFIG_OVERRIDE and overwriting with provided options."
-		cp "$USER_CONFIG_OVERRIDE" "$USER_CONFIG_OVERRIDE".old
-		#export PLATFORMIO_BUILD_FLAGS='-DUSE_CONFIG_OVERRIDE'
-		sed -i 's/^; *-DUSE_CONFIG_OVERRIDE/                            -DUSE_CONFIG_OVERRIDE/' platformio.ini
+		rm "$USER_CONFIG_OVERRIDE"
 		echo '#ifndef _USER_CONFIG_OVERRIDE_H_' >> $USER_CONFIG_OVERRIDE
 		echo '#define _USER_CONFIG_OVERRIDE_H_' >> $USER_CONFIG_OVERRIDE
 		echo '#warning **** user_config_override.h: Using Settings from this File ****' >> $USER_CONFIG_OVERRIDE	
+		echo '#undef CFG_HOLDER' >> $USER_CONFIG_OVERRIDE
+		echo '#define CFG_HOLDER	4617' >> $USER_CONFIG_OVERRIDE
 		for i in $(env | grep ^TASMOTA_); do
 			config=${i#TASMOTA_}
 			key=$(echo $config | cut -d '=' -f 1)
 			value=$(echo $config | cut -d '=' -f 2)
-			echo "#ifndef ${key}" >> $USER_CONFIG_OVERRIDE
+			echo "#undef ${key}" >> $USER_CONFIG_OVERRIDE
 			echo "#define ${key}	${value}" >> $USER_CONFIG_OVERRIDE
-			echo "#endif" >> $USER_CONFIG_OVERRIDE
 		done
 		echo '#endif' >> $USER_CONFIG_OVERRIDE
 	fi


### PR DESCRIPTION
my_user_config.h is processed before the generated user_config_override.h so all options and flags are already set. The created override file checks with ifndef if a option/flag but because these are all set by my_user_config.h none of paramerters provided to docker will have any effect on the build. Options and flags should use undef to remove the option and use define to set the option passed as an environment variable to the docker container.


It is nice to see that my Container was moved and not just deleted, also thank you for updating the Dockerfile so it can build the current tasmota development branch. I also removed some lines (leftover comments from my original script).

I would have left at least the original author of the scripts and container in the files, but this is just my opinion.

I hope you will support the docker build and update the container for future releases.