### PR TITLE
Simple change in `compile.sh` to make it easy to change the docker image

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,6 +5,12 @@
 CHECK_MARK="\033[0;32m\xE2\x9C\x94\033[0m"
 rundir=$(dirname $(readlink -f $0))
 
+# use default docker-tasmota image from hub.docker.com
+$DOCKER_IMAGE=blakadder/docker-tasmota
+# or uncomment and change if you want to run a locally built image
+#$DOCKER_IMAGE=docker-tasmota
+
+
 ## Check whether Tasmota/ exists and fetch newest Tasmota version from development branch
 if test -d `pwd`"/Tasmota"; then
     echo -e "Checking Tasmota GitHub for the most recent development version"
@@ -46,14 +52,14 @@ if test -d `pwd`"/Tasmota"; then
         echo -n "Compiling..."
         if  [ $# -ne 0 ]; then
                 if [[ $@ == "tasmota"* ]]; then
-                    docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID blakadder/docker-tasmota $(printf ' -e %s' $@) > docker-tasmota.log 2>&1 
+                    docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE $(printf ' -e %s' $@) > docker-tasmota.log 2>&1 
                     echo -e "\\r${CHECK_MARK} Finished!  \tCompilation log in docker-tasmota.log\n"
                     else
                     echo -e "\\r\e[31mNot a valid buildname.\e[0m Try one of the builds:\ntasmota\t\ttasmota-minimal\ttasmota-basic\ttasmota-ircustom\ntasmota-knx\ttasmota-sensors\ttasmota-display\ttasmota-ir\nFor translated builds:\ntasmota-BG [BR,CN,CZ,DE,ES,FR,GR,HE,HU,IT,KO,NL,PL,PT,RU,SE,SK,TR,TW,UK]"
                     exit 1
                 fi
             else
-            docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID blakadder/docker-tasmota > docker-tasmota.log 2>&1 
+            docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE > docker-tasmota.log 2>&1 
             echo -e "\\r${CHECK_MARK} Finished! \tCompilation log in docker-tasmota.log\n"
             echo -e "Find your builds in $rundir/Tasmota/build_output/firmware\n"
         fi


### PR DESCRIPTION
I just added a new bsh variable $DOCKER_IMAGE initially set at the beginning of the script to use official image.
And a ready line to uncomment to use a locally build image (without `blakadder/` prefix).
