### PR TITLE
reorder things to make cd command make more sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ To check compiling logs use `cat docker-tasmota.log`
 
 ## How to use the docker container
 1. Clone this repo and cd to the dir where its cloned:    
-    `git clone https://github.com/tasmota/docker-tasmota`      
-    `cd docker-tasmota`   
-    `cd Tasmota`   
+    ```
+    git clone https://github.com/tasmota/docker-tasmota
+    cd docker-tasmota
+    ```
 
-2. Run this to build the docker container:   
-`docker build -t docker-tasmota .`
+2. Run this to build the docker container:
+    `docker build -t docker-tasmota .`
 
    1. _Instead of 1. and 2:_ grab the docker image with `docker pull blakadder/docker-tasmota`
 
-3. Move to another directory where you want to clone Tasmota repo 
-`git clone https://github.com/arendst/Tasmota.git`
+3. Move to another directory where you want to clone Tasmota repo:
+    ```
+    git clone https://github.com/arendst/Tasmota.git
+    cd Tasmota
+    ```
 
 4. From the same directory run to compile the desired build   
 `docker run -ti --rm -v $(pwd)/Tasmota:/tasmota -u $UID:$GID docker-tasmota -e tasmota-PT`

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ To check compiling logs use `cat docker-tasmota.log`
 2. Run this to build the docker container:
     `docker build -t docker-tasmota .`
 
-   1. _Instead of 1. and 2:_ grab the docker image with `docker pull blakadder/docker-tasmota`
+   1. _Instead of 1. and 2:_ you can grab the latest docker image with `docker pull blakadder/docker-tasmota`
 
-3. Move to another directory where you want to clone Tasmota repo:
+3. Move to a directory where you want to clone Tasmota repo:
     ```
     git clone https://github.com/arendst/Tasmota.git
-    cd Tasmota
     ```
 
 4. From the same directory run to compile the desired build   


### PR DESCRIPTION
It looks like (since there's no Tasmota directory in docker-tasmota), that this `cd Tasmota` was meant for step 3.