### PR TITLE
Allow running from crontab

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -68,16 +68,17 @@ if test -d `pwd`"/Tasmota"; then
         fi
         ## Run container with provided arguments
         echo -n "Compiling..."
+	test -t 1 && DOCKER_TTY="-it"
         if  [ $# -ne 0 ]; then
                 if [[ $@ == "tasmota"* ]]; then
-                    docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE $(printf ' -e %s' $@) > docker-tasmota.log 2>&1 
+                    docker run ${DOCKER_TTY} --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE $(printf ' -e %s' $@) > docker-tasmota.log 2>&1 
                     echo -e "\\r${CHECK_MARK} Finished!  \tCompilation log in docker-tasmota.log\n"
                     else
                     echo -e "\\r\e[31mNot a valid buildname.\e[0m Try one of the builds:\ntasmota\t\ttasmota-minimal\ttasmota-basic\ttasmota-ircustom\ntasmota-knx\ttasmota-sensors\ttasmota-display\ttasmota-ir\nFor translated builds:\ntasmota-BG [BR,CN,CZ,DE,ES,FR,GR,HE,HU,IT,KO,NL,PL,PT,RU,SE,SK,TR,TW,UK]"
                     exit 1
                 fi
             else
-            docker run -it --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE > docker-tasmota.log 2>&1 
+            docker run ${DOCKER_TTY} --rm -v `pwd`/Tasmota:/tasmota -u $UID:$GID $DOCKER_IMAGE > docker-tasmota.log 2>&1 
             echo -e "\\r${CHECK_MARK} Finished! \tCompilation log in docker-tasmota.log\n"
             echo -e "Find your builds in $rundir/Tasmota/build_output/firmware\n"
         fi


### PR DESCRIPTION
Disable `-it` argument on `docker run` if no standard input is provided (== no tty)
This allows automated builds such as from crontab