### PR TITLE
Improvement suggestion: add_build_folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Tasmota/
 *.log
+user_config_override.h
+platformio_ovveride.ini
+builds/


### PR DESCRIPTION
Slight modification to have all firmware output filess (*.bin, *.bin.gz) sent to a selected folder. 
Being a separate folder could improve common maintenance/update operations:
- preventing accidentally exposing the whole code and setting when using webOTA;
- not requiring to manually copy the file to a different folder.
I hope it could be appreciated, feel free to discard otherwise

      - Added buildsdir variable (defaults to ./builds) to save all the compiled firmware
      - Added gzip compression when compiling selected firmwares (compression only worked when run with no parameters)
      - Updated .gitignore accordingly