### PR TITLE
fix check of platformio_override.ini

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -43,7 +43,7 @@ if test -d `pwd`"/Tasmota"; then
         ## Display builds
         if  [ $# -eq 0 ]; then
             ## Check script dir for platformio_override.ini
-            if test -f "platformio_override.ini"; then
+            if test -e "platformio_override.ini"; then
                 echo -e "Compiling builds defined in platformio_override.ini. Default file is overwritten.\n"
                 cp platformio_override.ini Tasmota/platformio_override.ini
                 else


### PR DESCRIPTION
if my view, the script was unable to copy the user platformio_override.ini to Tasmota/platformio_override.ini because it was no regular file. changing the test arguments helped (only check if file exists).
changed "**test -f**" to "**test -e**" to only check if it exists (not if regular file)