### PR TITLE
fix pip cannot write to /.cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY init_pio_tasmota /init_pio_tasmota
 
 # Install project dependencies using a init project.
 RUN cd /init_pio_tasmota &&\ 
+    platformio upgrade &&\
+    pio pkg update &&\
     pio run &&\
     cd ../ &&\ 
     rm -fr init_pio_tasmota &&\ 
@@ -22,9 +24,6 @@ RUN cd /init_pio_tasmota &&\
     mkdir /.cache /.local &&\
     chmod -R 777 /.cache /.local
 
-RUN platformio upgrade
-
-RUN platformio platform update
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ LABEL description="Docker Container with a complete build environment for Tasmot
 RUN pip install --upgrade pip &&\ 
     pip install --upgrade platformio
 
-RUN pip install --upgrade zopfli
-
 # Init project
 COPY init_pio_tasmota /init_pio_tasmota
 
@@ -20,7 +18,9 @@ RUN cd /init_pio_tasmota &&\
     cd ../ &&\ 
     rm -fr init_pio_tasmota &&\ 
     cp -r /root/.platformio / &&\ 
-    chmod -R 777 /.platformio
+    chmod -R 777 /.platformio &&\
+    mkdir /.cache /.local &&\
+    chmod -R 777 /.cache /.local
 
 RUN platformio upgrade
 


### PR DESCRIPTION
When new pip dependencies are added to Tasmota, pip install fails with
```
WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
```

This is due to the image being built with all folders belonging to `root` while the container is ran with `-u $UID:$GID` (otherwise the user won't have access to the generated files)

This error is the one that required the addition of `RUN pip install zopfli`

The fix is to create 2 folders `/.cache` and `/.local` and give full access to everyone so `pip install` can work as expected.
Not only the dedicated line for `zopfli` is no more needed (as it will be dynamically installed during build execution) but it also solve the installation of the new requirement for `tasmota_metrics`

Also replace the `RUN platformio platform update` by `RUN pio pkg update` as recommended by the obsolecence warning.
