### PR TITLE
Rework folder rights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /init_pio_tasmota &&\
     rm -fr init_pio_tasmota &&\ 
     cp -r /root/.platformio / &&\ 
     mkdir /.cache /.local &&\
-    chmod -R 777 /.platformio /usr/local/lib/python3.10/site-packages /.cache /.local
+    chmod -R 777 /.platformio /usr/local/lib /.cache /.local
 
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,8 @@ RUN cd /init_pio_tasmota &&\
     cd ../ &&\ 
     rm -fr init_pio_tasmota &&\ 
     cp -r /root/.platformio / &&\ 
-    chmod -R 777 /.platformio &&\
     mkdir /.cache /.local &&\
-    chmod -R 777 /.cache /.local
+    chmod -R 777 /.platformio /usr/local/lib/python3.10/site-packages /.cache /.local
 
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
My previous PR https://github.com/tasmota/docker-tasmota/pull/21 only partially solved the problem as the 1st ESP8266 built would still fails

Now rights are given to /usr/local/lib/python3.10/site-packages so platformio can install zopfli, tasmota_metrics and future package at the right position
Still kept /.cache and /.local to prevent another warning
